### PR TITLE
Fix byte-compilation issues

### DIFF
--- a/elvish-mode.el
+++ b/elvish-mode.el
@@ -5,6 +5,7 @@
 ;; Author: Adam Schwalm <adamschwalm@gmail.com>
 ;; Version: 0.1.0
 ;; URL: https://github.com/ALSchwalm/elvish-mode
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -70,16 +71,16 @@ expected.")
   "The regex to identify elvish keywords")
 
 (defconst elvish-function-pattern
-  (rx "fn" (one-or-more space) (group (eval elvish-symbol)) symbol-end)
+  (eval `(rx "fn" (one-or-more space) (group ,elvish-symbol) symbol-end))
   "The regex to identify elvish function names")
 
 (defconst elvish-variable-usage-pattern
-  (rx "$" (optional "@") (zero-or-more (eval elvish-symbol) ":")
-      (group (eval elvish-symbol)) symbol-end)
+  (eval `(rx "$" (optional "@") (zero-or-more ,elvish-symbol ":")
+             (group ,elvish-symbol) symbol-end))
   "The regex to identify variable usages")
 
 (defconst elvish-map-key-pattern
-  (rx "&" (group (eval elvish-symbol)) "=")
+  (eval `(rx "&" (group ,elvish-symbol) "="))
   "The regex to identify map keys")
 
 (defcustom elvish-auto-variables
@@ -97,12 +98,12 @@ expected.")
   ;; Elvish requires spaces around the equal for multiple assignment.
   ;; For now, we require for single assignment as well (to avoid highlighting
   ;; arguments, etc).
-  (rx (group (optional (one-or-more (eval elvish-symbol) (one-or-more space)))
-             (eval elvish-symbol)) (one-or-more space) "=" (one-or-more space))
+  (eval `(rx (group (optional (one-or-more ,elvish-symbol (one-or-more space)))
+                    ,elvish-symbol) (one-or-more space) "=" (one-or-more space)))
   "The regex to identify variable declarations")
 
 (defconst elvish-module-pattern
-  (rx (group (eval elvish-symbol)) ":" symbol-start)
+  (eval `(rx (group ,elvish-symbol) ":" symbol-start))
   "The regex to identify elvish module prefixes")
 
 ;;TODO: this doesn't support everything ParseFloat does (scientific notation, etc)


### PR DESCRIPTION
In preparation for MELPA submission, fixed some byte compilation
issues.

I'm on Emacs 25.2.1. This is the error I get on `master`, both from `byte-compile-file` manually invoked, and when trying to build using MELPA's build mechanisms:

```
Compiling file /Users/taazadi1/Personal/devel/elvish/elvish-mode/elvish-mode.el at Thu Jul 27 11:17:58 2017
Entering directory ‘/Users/taazadi1/Personal/devel/elvish/elvish-mode/’
elvish-mode.el:72:1:Error: Symbol’s value as variable is void: elvish-symbol
```

With the changes in this branch, the file compiles cleanly.

Any ideas for a different fix?